### PR TITLE
Update wininnwa.json

### DIFF
--- a/myanmar/data/wininnwa.json
+++ b/myanmar/data/wininnwa.json
@@ -179,7 +179,7 @@
   "aaVowel": {
     "aaVowel_tall": "g",
     "aaVowel-asat_tall": ":",
-    "aaVowel-asat": "",
+    "aaVowel-asat": "mf",
     "aaVowel": "m"
   },
   "dotBelow": {


### PR DESCRIPTION
"aaVowel - asat" is set to "mf" to fix the issue of missing when conversion from Unicode to Win.